### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/openworkflowdev/openworkflow/security/code-scanning/1](https://github.com/openworkflowdev/openworkflow/security/code-scanning/1)

The fix is to explicitly set the `permissions` block in the workflow. Because none of the steps in the job require write access to repository contents and mostly read-code and report status, you should set the permissions to `contents: read` at either root level or within the `ci` job. This will prevent the workflow from inheriting potentially excessive defaults and restrict GitHub Actions token usage. The change can be made at the top level of the workflow (recommended for single-job workflows), by inserting the following after the `name: CI` line and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
