### PR TITLE
Validate deterministic step order

### DIFF
--- a/packages/openworkflow/index.ts
+++ b/packages/openworkflow/index.ts
@@ -4,4 +4,4 @@ export { OpenWorkflow } from "./client.js";
 export * from "./backend.js";
 
 export type { WorkerOptions } from "./worker.js";
-export { Worker } from "./worker.js";
+export { NonDeterministicError, Worker } from "./worker.js";


### PR DESCRIPTION
This is a draft PR. There are likely still untested edge cases, so this was opened to review before merging since `validateReplayOrder` is easy to get wrong

### Summary

Adds deterministic replay validation that detects & fails on step name/order mismatches during replay.

### Changes

- Workers throw `NonDeterministicError` when a workflow is replayed after a worker restart and the actual recorded step history does not match the expected/current sequence
- Adds a ton of tests
- Adds a short architecture summary to the docs
