### PR TITLE
Add dirs config for workflow discovery

### DIFF
--- a/examples/workflow-discovery/index.ts
+++ b/examples/workflow-discovery/index.ts
@@ -1,0 +1,39 @@
+import greetingDefaultWorkflow from "./openworkflow/greeting-default.js";
+import { greetingWorkflow } from "./openworkflow/greeting.js";
+import { addWorkflow, multiplyWorkflow } from "./openworkflow/math.js";
+import { createClient } from "openworkflow/internal";
+
+const ow = await createClient();
+
+// Greeting Workflow
+console.log("Running greeting workflow...");
+const greetingHandle = await ow.runWorkflow(greetingWorkflow.spec, {
+  name: "Alice",
+});
+const greetingResult = await greetingHandle.result();
+console.log("Greeting result:", greetingResult);
+
+// Greeting Default Workflow
+console.log("\nRunning greeting default workflow...");
+const greetingDefaultHandle = await ow.runWorkflow(
+  greetingDefaultWorkflow.spec,
+  {
+    name: "Alice",
+  },
+);
+const greetingDefaultResult = await greetingDefaultHandle.result();
+console.log("Greeting default result:", greetingDefaultResult);
+
+// Math Workflows
+console.log("\nRunning add workflow...");
+const addHandle = await ow.runWorkflow(addWorkflow.spec, { a: 5, b: 3 });
+const addResult = await addHandle.result();
+console.log("Add result:", addResult);
+
+console.log("\nRunning multiply workflow...");
+const multiplyHandle = await ow.runWorkflow(multiplyWorkflow.spec, {
+  a: 4,
+  b: 7,
+});
+const multiplyResult = await multiplyHandle.result();
+console.log("Multiply result:", multiplyResult);

--- a/examples/workflow-discovery/openworkflow.config.ts
+++ b/examples/workflow-discovery/openworkflow.config.ts
@@ -1,0 +1,10 @@
+import { BackendSqlite } from "@openworkflow/backend-sqlite";
+import { defineConfig } from "openworkflow";
+
+// eslint-disable-next-line sonarjs/publicly-writable-directories
+const sqliteFileName = "/tmp/openworkflow_example_workflow_discovery.db";
+
+export default defineConfig({
+  backend: BackendSqlite.connect(sqliteFileName),
+  dirs: "./openworkflow",
+});

--- a/examples/workflow-discovery/openworkflow/greeting-default.ts
+++ b/examples/workflow-discovery/openworkflow/greeting-default.ts
@@ -1,0 +1,18 @@
+import { GreetingInput, GreetingOutput } from "./greeting.js";
+import { defineWorkflow } from "openworkflow/internal";
+
+// A workflow with a default export
+export default defineWorkflow<GreetingInput, GreetingOutput>(
+  { name: "greeting-default", version: "1.0.0" },
+  async ({ input, step }) => {
+    const greeting = await step.run({ name: "generate-greeting" }, () => {
+      return `Hello, ${input.name}!`;
+    });
+
+    const message = await step.run({ name: "format-message" }, () => {
+      return `${greeting} Welcome to OpenWorkflow.`;
+    });
+
+    return { message };
+  },
+);

--- a/examples/workflow-discovery/openworkflow/greeting.ts
+++ b/examples/workflow-discovery/openworkflow/greeting.ts
@@ -1,0 +1,25 @@
+import { defineWorkflow } from "openworkflow/internal";
+
+export interface GreetingInput {
+  name: string;
+}
+
+export interface GreetingOutput {
+  message: string;
+}
+
+// A workflow with a named export (greetingWorkflow)
+export const greetingWorkflow = defineWorkflow<GreetingInput, GreetingOutput>(
+  { name: "greeting", version: "1.0.0" },
+  async ({ input, step }) => {
+    const greeting = await step.run({ name: "generate-greeting" }, () => {
+      return `Hello, ${input.name}!`;
+    });
+
+    const message = await step.run({ name: "format-message" }, () => {
+      return `${greeting} Welcome to OpenWorkflow.`;
+    });
+
+    return { message };
+  },
+);

--- a/examples/workflow-discovery/openworkflow/math.ts
+++ b/examples/workflow-discovery/openworkflow/math.ts
@@ -1,0 +1,43 @@
+import { defineWorkflow } from "openworkflow/internal";
+
+interface AddNumbersInput {
+  a: number;
+  b: number;
+}
+
+interface AddNumbersOutput {
+  result: number;
+}
+
+// One of two exported workflows
+export const addWorkflow = defineWorkflow<AddNumbersInput, AddNumbersOutput>(
+  { name: "add-numbers", version: "1.0.0" },
+  async ({ input, step }) => {
+    const result = await step.run({ name: "add" }, () => {
+      return input.a + input.b;
+    });
+
+    return { result };
+  },
+);
+
+interface MultiplyInput {
+  a: number;
+  b: number;
+}
+
+interface MultiplyOutput {
+  result: number;
+}
+
+// The second of two exported workflows
+export const multiplyWorkflow = defineWorkflow<MultiplyInput, MultiplyOutput>(
+  { name: "multiply-numbers", version: "1.0.0" },
+  async ({ input, step }) => {
+    const result = await step.run({ name: "multiply" }, () => {
+      return input.a * input.b;
+    });
+
+    return { result };
+  },
+);

--- a/examples/workflow-discovery/package.json
+++ b/examples/workflow-discovery/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "example-workflow-discovery",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "worker": "tsx ../../packages/cli/index.ts worker start"
+  },
+  "dependencies": {
+    "@openworkflow/backend-sqlite": "file:../../packages/backend-sqlite",
+    "openworkflow": "file:../../packages/openworkflow"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/examples/workflow-discovery/tsconfig.json
+++ b/examples/workflow-discovery/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7964,6 +7964,7 @@
         "@clack/prompts": "^0.11.0",
         "commander": "^14.0.2",
         "consola": "^3.4.2",
+        "jiti": "^2.4.2",
         "nypm": "^0.6.2"
       },
       "bin": {

--- a/packages/cli/commands.ts
+++ b/packages/cli/commands.ts
@@ -171,8 +171,10 @@ function discoverWorkflowFiles(dirs: string[], baseDir: string): string[] {
     let entries;
     try {
       entries = readdirSync(absoluteDir, { withFileTypes: true });
-    } catch {
+    } catch (error) {
       // doesn't exist or can't be read, skip
+      const errMessage = error instanceof Error ? error.message : String(error);
+      consola.debug(`Failed to read directory: ${absoluteDir} - ${errMessage}`);
       return;
     }
 

--- a/packages/cli/commands.ts
+++ b/packages/cli/commands.ts
@@ -1,11 +1,13 @@
 import { CLIError } from "./errors.js";
 import * as p from "@clack/prompts";
 import { consola } from "consola";
-import { readFileSync, writeFileSync } from "node:fs";
+import { createJiti } from "jiti";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { addDependency, detectPackageManager } from "nypm";
 import { OpenWorkflow, WorkerConfig } from "openworkflow";
-import { loadConfig } from "openworkflow/internal";
+import { isWorkflow, loadConfig, Workflow } from "openworkflow/internal";
 
 /** Initialize OpenWorkflow in the current project. */
 export async function init(): Promise<void> {
@@ -82,12 +84,57 @@ export async function init(): Promise<void> {
 export async function workerStart(cliOptions: WorkerConfig): Promise<void> {
   consola.start("Starting worker...");
 
-  const { config } = await loadConfig();
+  const { config, configFile } = await loadConfig();
+  if (!configFile) {
+    throw new CLIError(
+      "No config file found.",
+      "Run `ow init` to create a config file.",
+    );
+  }
+
+  // discover and import workflows
+  let dirs: string[];
+  if (config.dirs) {
+    dirs = Array.isArray(config.dirs) ? config.dirs : [config.dirs];
+  } else {
+    dirs = ["./openworkflow"];
+  }
+  consola.info(`Discovering workflows from: ${dirs.join(", ")}`);
+
+  const configFileDir = path.dirname(configFile);
+  const files = discoverWorkflowFiles(dirs, configFileDir);
+  if (files.length === 0) {
+    throw new CLIError(
+      "No workflows found.",
+      `No workflow files found in: ${dirs.join(", ")}\n` +
+        `Make sure your workflow files export workflows created with defineWorkflow().`,
+    );
+  }
+  consola.info(`Found ${String(files.length)} workflow file(s)`);
+
+  const workflows = await importWorkflows(files);
+  if (workflows.length === 0) {
+    throw new CLIError(
+      "No workflows found.",
+      `No workflows exported in: ${dirs.join(", ")}\n` +
+        `Make sure your workflow files export workflows created with defineWorkflow().`,
+    );
+  }
+  consola.success(
+    `Loaded ${String(workflows.length)} workflow(s): ${workflows.map((w) => w.spec.name).join(", ")}`,
+  );
 
   const ow = new OpenWorkflow({ backend: config.backend });
+
+  // register discovered workflows
+  for (const workflow of workflows) {
+    ow.implementWorkflow(workflow.spec, workflow.fn);
+  }
+
   const worker = ow.newWorker({ ...config.worker, ...cliOptions });
 
   let shuttingDown = false;
+
   /** Stop the worker on process shutdown. */
   async function gracefulShutdown(): Promise<void> {
     if (shuttingDown) return;
@@ -102,4 +149,91 @@ export async function workerStart(cliOptions: WorkerConfig): Promise<void> {
 
   await worker.start();
   consola.success("Worker started.");
+}
+
+/**
+ * Discover workflow files from directories.
+ * Recursively scans directories for .ts and .js files.
+ * @param dirs - Directory or directories to scan for workflow files
+ * @param baseDir - Base directory to resolve relative paths from
+ * @returns Array of absolute file paths
+ */
+function discoverWorkflowFiles(dirs: string[], baseDir: string): string[] {
+  const discoveredFiles: string[] = [];
+
+  /**
+   * Recursively scan a directory for workflow files.
+   * @param dir - Directory to scan
+   */
+  function scanDirectory(dir: string): void {
+    const absoluteDir = path.isAbsolute(dir) ? dir : path.resolve(baseDir, dir);
+
+    let entries;
+    try {
+      entries = readdirSync(absoluteDir, { withFileTypes: true });
+    } catch {
+      // doesn't exist or can't be read, skip
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        scanDirectory(fullPath);
+      } else if (
+        entry.isFile() &&
+        (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) &&
+        !entry.name.endsWith(".d.ts")
+      ) {
+        discoveredFiles.push(fullPath);
+      }
+    }
+  }
+
+  for (const dir of dirs) {
+    scanDirectory(dir);
+  }
+
+  return discoveredFiles;
+}
+
+/**
+ * Import workflow files and extract workflow exports.
+ * Supports both named exports and default exports.
+ * @param files - Array of absolute file paths to import
+ * @returns Array of discovered workflows
+ */
+async function importWorkflows(
+  files: string[],
+): Promise<Workflow<unknown, unknown, unknown>[]> {
+  const workflows: Workflow<unknown, unknown, unknown>[] = [];
+  const jiti = createJiti(import.meta.url);
+
+  for (const file of files) {
+    // import the module
+    let module: Record<string, unknown>;
+    try {
+      module = await jiti.import(pathToFileURL(file).href);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new CLIError(
+        `Failed to import workflow file: ${file}`,
+        `Error: ${errorMessage}`,
+      );
+    }
+
+    // extract workflow exports (named and default)
+    for (const [key, value] of Object.entries(module)) {
+      if (isWorkflow(value)) {
+        const workflow = value as Workflow<unknown, unknown, unknown>;
+        workflows.push(workflow);
+        consola.debug(
+          `Found workflow "${workflow.spec.name}" in ${file} (${key})`,
+        );
+      }
+    }
+  }
+
+  return workflows;
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "@clack/prompts": "^0.11.0",
     "commander": "^14.0.2",
     "consola": "^3.4.2",
+    "jiti": "^2.4.2",
     "nypm": "^0.6.2"
   },
   "devDependencies": {

--- a/packages/cli/templates/openworkflow.config.ts
+++ b/packages/cli/templates/openworkflow.config.ts
@@ -14,4 +14,5 @@ const backend =
 
 export default defineConfig({
   backend,
+  dirs: "./openworkflow",
 });

--- a/packages/openworkflow/client.test.ts
+++ b/packages/openworkflow/client.test.ts
@@ -1,10 +1,11 @@
 import { BackendPostgres } from "../backend-postgres/backend.js";
 import { DEFAULT_DATABASE_URL } from "../backend-postgres/postgres.js";
-import { declareWorkflow, OpenWorkflow } from "./client.js";
+import { createClient, declareWorkflow, OpenWorkflow } from "./client.js";
+import * as configModule from "./config.js";
 import { type as arkType } from "arktype";
 import { randomUUID } from "node:crypto";
 import * as v from "valibot";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
   number as yupNumber,
   object as yupObject,
@@ -423,6 +424,25 @@ describe("OpenWorkflow", () => {
       const result = await handle.result();
       expect(result).toEqual({ doubled: 42 });
     });
+  });
+});
+
+describe("createClient", () => {
+  test("creates client from project config file", async () => {
+    const mockBackend = await BackendPostgres.connect(DEFAULT_DATABASE_URL, {
+      namespaceId: randomUUID(),
+    });
+
+    vi.spyOn(configModule, "loadConfig").mockResolvedValueOnce({
+      config: { backend: mockBackend },
+      configFile: "/mock/openworkflow.config.ts",
+      cwd: "/mock",
+      layers: [],
+    });
+
+    const client = await createClient();
+
+    expect(client).toBeInstanceOf(OpenWorkflow);
   });
 });
 

--- a/packages/openworkflow/client.ts
+++ b/packages/openworkflow/client.ts
@@ -1,4 +1,5 @@
 import type { Backend } from "./backend.js";
+import { loadConfig } from "./config.js";
 import type { StandardSchemaV1 } from "./core/schema.js";
 import type {
   SchemaInput,
@@ -161,6 +162,15 @@ export class OpenWorkflow {
 
     return new RunnableWorkflow(this, workflow);
   }
+}
+
+/**
+ * Create an OpenWorkflow client from the project config file.
+ * @returns OpenWorkflow instance
+ */
+export async function createClient(): Promise<OpenWorkflow> {
+  const { config } = await loadConfig();
+  return new OpenWorkflow({ backend: config.backend });
 }
 
 /**

--- a/packages/openworkflow/config.ts
+++ b/packages/openworkflow/config.ts
@@ -5,6 +5,14 @@ import { loadConfig as loadC12Config } from "c12";
 export interface OpenWorkflowConfig {
   backend: Backend;
   worker?: WorkerConfig;
+  /**
+   * Directory or directories to scan for workflow files.
+   * All `.ts` and `.js` files in these directories (recursively) will be loaded.
+   * Workflow files should export workflows created with `defineWorkflow()`.
+   * @example "./openworkflow"
+   * @example ["./openworkflow", "./src/openworkflow", "./workflows"]
+   */
+  dirs?: string | string[];
 }
 
 export type WorkerConfig = Pick<WorkerOptions, "concurrency">;

--- a/packages/openworkflow/internal.ts
+++ b/packages/openworkflow/internal.ts
@@ -1,6 +1,13 @@
 // config
 export { loadConfig } from "./config.js";
 
+// client
+export { createClient } from "./client.js";
+
+// workflow
+export type { Workflow } from "./workflow.js";
+export { defineWorkflow, isWorkflow } from "./workflow.js";
+
 // backend
 export * from "./backend.js";
 

--- a/packages/openworkflow/workflow.test.ts
+++ b/packages/openworkflow/workflow.test.ts
@@ -1,4 +1,4 @@
-import { defineWorkflow, defineWorkflowSpec } from "./workflow.js";
+import { defineWorkflow, defineWorkflowSpec, isWorkflow } from "./workflow.js";
 import { describe, expect, test } from "vitest";
 
 describe("defineWorkflowSpec", () => {
@@ -24,6 +24,47 @@ describe("defineWorkflow", () => {
       spec,
       fn,
     });
+  });
+});
+
+describe("isWorkflow", () => {
+  test("returns true for valid workflow objects", () => {
+    const workflow = defineWorkflow({ name: "test" }, () => "done");
+    expect(isWorkflow(workflow)).toBe(true);
+  });
+
+  test("returns false for null", () => {
+    expect(isWorkflow(null)).toBe(false);
+  });
+
+  test("returns false for undefined", () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    expect(isWorkflow(undefined)).toBe(false);
+  });
+
+  test("returns false for primitives", () => {
+    expect(isWorkflow("string")).toBe(false);
+    expect(isWorkflow(123)).toBe(false);
+    expect(isWorkflow(true)).toBe(false);
+  });
+
+  test("returns false for objects without spec", () => {
+    expect(isWorkflow({ fn: () => "result" })).toBe(false);
+  });
+
+  test("returns false for objects without fn", () => {
+    expect(isWorkflow({ spec: { name: "test" } })).toBe(false);
+  });
+
+  test("returns false for objects with invalid spec", () => {
+    expect(isWorkflow({ spec: null, fn: () => "result" })).toBe(false);
+    expect(isWorkflow({ spec: "invalid", fn: () => "result" })).toBe(false);
+  });
+
+  test("returns false for objects with invalid fn", () => {
+    expect(isWorkflow({ spec: { name: "test" }, fn: "not-a-function" })).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/openworkflow/workflow.ts
+++ b/packages/openworkflow/workflow.ts
@@ -1,6 +1,9 @@
 import type { StandardSchemaV1 } from "./core/schema.js";
 import { WorkflowFunction } from "./execution.js";
 
+/**
+ * A workflow spec.
+ */
 export interface WorkflowSpec<Input, Output, RawInput> {
   /** The name of the workflow. */
   readonly name: string;
@@ -84,4 +87,29 @@ export function defineWorkflow<Input, Output, RawInput>(
     spec,
     fn,
   };
+}
+
+/**
+ * Type guard to check if a value is a Workflow object.
+ * @param value - The value to check
+ * @returns True if the value is a Workflow
+ */
+export function isWorkflow(value: unknown) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const maybeWorkflow = value as Record<string, unknown>;
+  if (!("spec" in maybeWorkflow) || !("fn" in maybeWorkflow)) {
+    return false;
+  }
+
+  const { spec, fn } = maybeWorkflow;
+  return (
+    typeof spec === "object" &&
+    spec !== null &&
+    "name" in spec &&
+    typeof spec.name === "string" &&
+    typeof fn === "function"
+  );
 }


### PR DESCRIPTION
Adds automatic workflow config and discovery, allowing workers to automatically discover and register workflows from configured directories instead of requiring manual registration.

Key changes:

- Add `createClient()` to create a client using the config
- Add `dirs` to the config (changed from earlier `workflows`)
- Add automatic workflow discovery based on the configured `dirs`
- Add an example