### PR TITLE
ts refactor

### DIFF
--- a/benchmarks/basic/tsconfig.json
+++ b/benchmarks/basic/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"

--- a/benchmarks/basic/tsconfig.json
+++ b/benchmarks/basic/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "include": ["**/*.ts"],

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "include": ["**/*.ts"],

--- a/examples/declare-workflow/tsconfig.json
+++ b/examples/declare-workflow/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"

--- a/examples/declare-workflow/tsconfig.json
+++ b/examples/declare-workflow/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "include": ["**/*.ts"],

--- a/examples/with-schema-validation/tsconfig.json
+++ b/examples/with-schema-validation/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"

--- a/examples/with-schema-validation/tsconfig.json
+++ b/examples/with-schema-validation/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "include": ["**/*.ts"],

--- a/examples/workflow-discovery/tsconfig.json
+++ b/examples/workflow-discovery/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/examples/workflow-discovery/tsconfig.json
+++ b/examples/workflow-discovery/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "outDir": "dist"
   },
   "include": ["**/*.ts"],
   "exclude": ["dist"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "turbo build",
-    "ci": "npm run format && npm run lint && npm run typecheck && npm run build && npm run test:coverage",
+    "ci": "npm run format && npm run build && npm run lint && npm run typecheck && npm run test:coverage",
     "format": "prettier --check . --ignore-path .gitignore --ignore-path .prettierignore",
     "format:fix": "prettier --write . --ignore-path .gitignore --ignore-path .prettierignore",
     "knip": "knip",

--- a/packages/backend-postgres/package.json
+++ b/packages/backend-postgres/package.json
@@ -5,7 +5,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "development": "./index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/backend-postgres/tsconfig.json
+++ b/packages/backend-postgres/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": ["../../tsconfig.base.json"],
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "references": [{ "path": "../openworkflow" }],

--- a/packages/backend-postgres/tsconfig.json
+++ b/packages/backend-postgres/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": ["../../tsconfig.base.json"],
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"
   },
+  "references": [{ "path": "../openworkflow" }],
   "include": ["**/*.ts"],
   "exclude": ["dist"]
 }

--- a/packages/backend-sqlite/package.json
+++ b/packages/backend-sqlite/package.json
@@ -5,7 +5,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "development": "./index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/backend-sqlite/tsconfig.json
+++ b/packages/backend-sqlite/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"
   },
+  "references": [{ "path": "../openworkflow" }],
   "include": ["**/*.ts"],
   "exclude": ["dist"]
 }

--- a/packages/backend-sqlite/tsconfig.json
+++ b/packages/backend-sqlite/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "references": [{ "path": "../openworkflow" }],

--- a/packages/backend-test/package.json
+++ b/packages/backend-test/package.json
@@ -5,7 +5,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "development": "./index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/backend-test/tsconfig.json
+++ b/packages/backend-test/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"
   },
+  "references": [{ "path": "../openworkflow" }],
   "include": ["**/*.ts"],
   "exclude": ["dist"]
 }

--- a/packages/backend-test/tsconfig.json
+++ b/packages/backend-test/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "references": [{ "path": "../openworkflow" }],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,12 +5,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "development": "./index.ts",
       "default": "./dist/index.js"
     },
     "./internal": {
       "types": "./dist/internal.d.ts",
-      "development": "./internal.ts",
       "default": "./dist/internal.js"
     }
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"
   },
+  "references": [{ "path": "../openworkflow" }],
   "include": ["**/*.ts"],
   "exclude": ["dist"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "references": [{ "path": "../openworkflow" }],

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "noEmit": false, // TS6310
+    "allowImportingTsExtensions": false, // TS5096, caused by disabling noEmit
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -4,6 +4,7 @@
     "@tsconfig/vite-react/tsconfig.json" // https://www.npmjs.com/package/@tsconfig/vite-react
   ],
   "compilerOptions": {
+    "noEmit": false, // TS6310
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../tsconfig.json",
+    "../../tsconfig.base.json",
     "@tsconfig/vite-react/tsconfig.json" // https://www.npmjs.com/package/@tsconfig/vite-react
   ],
   "compilerOptions": {
@@ -9,6 +9,7 @@
       "@/*": ["./src/*"]
     }
   },
+  "references": [{ "path": "../cli" }, { "path": "../openworkflow" }],
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["dist"]
 }

--- a/packages/openworkflow/package.json
+++ b/packages/openworkflow/package.json
@@ -28,12 +28,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "development": "./index.ts",
       "default": "./dist/index.js"
     },
     "./internal": {
       "types": "./dist/internal.d.ts",
-      "development": "./internal.ts",
       "default": "./dist/internal.js"
     }
   },

--- a/packages/openworkflow/tsconfig.json
+++ b/packages/openworkflow/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": ["../../tsconfig.base.json"],
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"

--- a/packages/openworkflow/tsconfig.json
+++ b/packages/openworkflow/tsconfig.json
@@ -4,5 +4,8 @@
     "outDir": "dist"
   },
   "include": ["**/*.ts"],
-  "exclude": ["dist"]
+  "exclude": [
+    "dist",
+    "**/*.test.ts" // see note in ./tsconfig.test.json
+  ]
 }

--- a/packages/openworkflow/tsconfig.json
+++ b/packages/openworkflow/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "dist"
   },
   "include": ["**/*.ts"],
-  "exclude": ["**/*.test.ts", "dist"]
+  "exclude": ["dist"]
 }

--- a/packages/openworkflow/tsconfig.json
+++ b/packages/openworkflow/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": ["../../tsconfig.base.json"],
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist"
   },
   "include": ["**/*.ts"],

--- a/packages/openworkflow/tsconfig.test.json
+++ b/packages/openworkflow/tsconfig.test.json
@@ -1,0 +1,11 @@
+// this config is a workaround to add backend-postgres as a reference for our
+// test files without a circular reference in the main tsconfig.json
+{
+  "extends": ["./tsconfig.json"],
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "references": [{ "path": "." }, { "path": "../backend-postgres" }],
+  "include": ["**/*.test.ts"],
+  "exclude": ["dist"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist",
-    "customConditions": ["development"],
 
     "composite": true,
     "declaration": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,8 +4,6 @@
     "@tsconfig/node22/tsconfig.json" // https://www.npmjs.com/package/@tsconfig/node22
   ],
   "compilerOptions": {
-    "outDir": "dist",
-
     "composite": true,
     "declaration": true,
     "sourceMap": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "extends": [
+    "@tsconfig/strictest/tsconfig.json", // https://www.npmjs.com/package/@tsconfig/strictest
+    "@tsconfig/node22/tsconfig.json" // https://www.npmjs.com/package/@tsconfig/node22
+  ],
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "customConditions": ["development"],
+
+    "composite": true,
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true
+  },
+  "include": ["**/*.ts"],
+
+  // temporary - run `npm run typecheck` from the package root until we migrate
+  // our typechecks over to turbo
+  "exclude": ["packages/dashboard", "dist"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,6 @@
     "@tsconfig/node22/tsconfig.json" // https://www.npmjs.com/package/@tsconfig/node22
   ],
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist",
 
     "composite": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,10 +8,5 @@
     "declaration": true,
     "sourceMap": true,
     "declarationMap": true
-  },
-  "include": ["**/*.ts"],
-
-  // temporary - run `npm run typecheck` from the package root until we migrate
-  // our typechecks over to turbo
-  "exclude": ["packages/dashboard", "dist"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,11 @@
 {
-  "extends": [
-    "@tsconfig/strictest/tsconfig.json", // https://www.npmjs.com/package/@tsconfig/strictest
-    "@tsconfig/node22/tsconfig.json" // https://www.npmjs.com/package/@tsconfig/node22
-  ],
-  "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist",
-    "customConditions": ["development"],
-
-    "composite": true,
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
-  },
-  "include": ["**/*.ts"],
-
-  // temporary - run `npm run typecheck` from the package root until we migrate
-  // our typechecks over to turbo
-  "exclude": ["packages/dashboard", "dist"]
+  "files": [],
+  "references": [
+    { "path": "./packages/openworkflow" },
+    { "path": "./packages/backend-postgres" },
+    { "path": "./packages/backend-sqlite" },
+    { "path": "./packages/backend-test" },
+    { "path": "./packages/cli" },
+    { "path": "./packages/dashboard" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,9 @@
     { "path": "./packages/backend-test" },
     { "path": "./packages/cli" },
     { "path": "./packages/dashboard" }
-  ]
+  ],
+
+  // project-wide settings for configs, workflows, etc.
+  "extends": "./tsconfig.base.json",
+  "include": ["openworkflow/**/*.ts", "*.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "files": [],
   "references": [
+    { "path": "./benchmarks/basic" },
+    { "path": "./examples/basic" },
+    { "path": "./examples/declare-workflow" },
+    { "path": "./examples/with-schema-validation" },
+    { "path": "./examples/workflow-discovery" },
     { "path": "./packages/openworkflow" },
     { "path": "./packages/backend-postgres" },
     { "path": "./packages/backend-sqlite" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,10 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["openworkflow/**/*.ts", "*.config.ts"],
+  "include": [
+    "openworkflow/**/*.ts",
+    "*.config.ts",
+    "packages/openworkflow/**/*.test.ts" // needed to work with packages/openworkflow/tsconfig.test.json
+  ],
   "exclude": ["dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  // https://www.typescriptlang.org/docs/handbook/project-references.html#overall-structure
   "files": [],
   "references": [
     { "path": "./benchmarks/basic" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,9 @@
 
   // project-wide settings for configs, workflows, etc.
   "extends": "./tsconfig.base.json",
-  "include": ["openworkflow/**/*.ts", "*.config.ts"]
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["openworkflow/**/*.ts", "*.config.ts"],
+  "exclude": ["dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     coverage: {
       include: ["packages/**/*.ts"],
       exclude: [
+        "**/*.testsuite.ts",
         "**/dist/**",
         "**/scripts/*.ts",
         "vitest.global-setup.ts",


### PR DESCRIPTION
- **Switch to TypeScript project references**
- **Clean up "development" imports**
- **Switch benchmarks and examples to use ts project references**
- **Remove rootDir from tsconfigs**
- **Remove outDir from base tsconfig**
- **Remove test files from tsconfig exclusion**
- **Add ts project references doc link**
- **Add project-wide settings to root tsconfig**
- **Set dashboard tsconfig to noEmit to resolve TS6310**
- **Add dist outDir/exclude to project tsconfig**
- **Add tsconfig.test.json for references workaround**
- **Disable allowImportingTsExtensions in dashboard tsconfig**
- **Include openworkflow package tests in root tsconfig**
- **Add exclusion for test suite files in coverage configuration**
