### PR TITLE
feat(postgres): support configurable schema

### DIFF
--- a/packages/docs/docs/postgres.mdx
+++ b/packages/docs/docs/postgres.mdx
@@ -60,6 +60,9 @@ const backend = await BackendPostgres.connect(url, {
   // Namespace for multi-tenant isolation (default: "default")
   namespaceId: "production",
 
+  // Database schema for OpenWorkflow tables (default: "openworkflow")
+  schema: "openworkflow",
+
   // Whether to run migrations on connect (default: true)
   runMigrations: true,
 });
@@ -68,7 +71,8 @@ const backend = await BackendPostgres.connect(url, {
 ## Migrations
 
 By default, `BackendPostgres.connect()` runs database migrations automatically.
-This creates the `openworkflow` schema and required tables.
+This creates the configured schema (default: `openworkflow`) and required
+tables.
 
 To disable automatic migrations:
 
@@ -82,10 +86,11 @@ When disabled, ensure you run migrations separately before starting workers.
 
 ## Schema
 
-OpenWorkflow creates tables in the `openworkflow` schema:
+OpenWorkflow creates tables in the configured schema (default:
+`openworkflow`):
 
-- `openworkflow.workflow_runs` - Stores workflow run state
-- `openworkflow.step_attempts` - Stores step execution history
+- `<schema>.workflow_runs` - Stores workflow run state
+- `<schema>.step_attempts` - Stores step execution history
 
 This keeps OpenWorkflow data separate from your application tables.
 
@@ -135,4 +140,4 @@ automatically and connections are reused across workflow executions.
 - The connecting user needs permissions to:
   - Create schemas (for migrations)
   - Create tables (for migrations)
-  - Read/write to the `openworkflow` schema
+  - Read/write to the configured schema (default: `openworkflow`)

--- a/packages/docs/docs/production.mdx
+++ b/packages/docs/docs/production.mdx
@@ -40,7 +40,7 @@ For most production use cases, use PostgreSQL 14 or later:
 
 - The connecting user needs permissions to create schemas and tables (for
   migrations)
-- Workflow state is stored in the `openworkflow` schema
+- Workflow state is stored in the configured schema (default: `openworkflow`)
 
 For single-server deployments, SQLite works well.
 
@@ -63,6 +63,7 @@ export default defineConfig({
     process.env.OPENWORKFLOW_POSTGRES_URL!,
     {
       namespaceId: process.env.OPENWORKFLOW_NAMESPACE_ID || "production",
+      schema: process.env.OPENWORKFLOW_SCHEMA || "openworkflow",
     },
   ),
   dirs: ["./openworkflow"],
@@ -72,16 +73,17 @@ export default defineConfig({
 });
 ```
 
-In this example, we use the `OPENWORKFLOW_POSTGRES_URL` and
-`OPENWORKFLOW_NAMESPACE_ID` env vars to dynamically set the Postgres URL and
-namespace, but you can set this up however you'd like.
+In this example, we use `OPENWORKFLOW_POSTGRES_URL`,
+`OPENWORKFLOW_NAMESPACE_ID`, and `OPENWORKFLOW_SCHEMA` env vars to dynamically
+set the Postgres URL, namespace, and schema, but you can set this up however
+you'd like.
 
 ### 3. Migrations
 
 Migrations run automatically when the backend connects. OpenWorkflow creates:
 
-- `openworkflow.workflow_runs` - Stores workflow run state
-- `openworkflow.step_attempts` - Stores step execution history
+- `<schema>.workflow_runs` - Stores workflow run state
+- `<schema>.step_attempts` - Stores step execution history
 
 ### 4. Deploy Workers
 

--- a/packages/openworkflow/client.test.ts
+++ b/packages/openworkflow/client.test.ts
@@ -375,13 +375,15 @@ describe("OpenWorkflow", () => {
     const internalBackend = backend as unknown as {
       pg: Postgres;
       namespaceId: string;
+      schema: string;
     };
     const staleCreatedAt = new Date(
       Date.now() - DEFAULT_RUN_IDEMPOTENCY_PERIOD_MS - 60_000,
     );
+    const workflowRunsTable = internalBackend.pg`${internalBackend.pg(internalBackend.schema)}.${internalBackend.pg("workflow_runs")}`;
 
     await internalBackend.pg`
-      UPDATE "openworkflow"."workflow_runs"
+      UPDATE ${workflowRunsTable}
       SET "created_at" = ${staleCreatedAt}
       WHERE "namespace_id" = ${internalBackend.namespaceId}
         AND "id" = ${first.workflowRun.id}

--- a/packages/openworkflow/postgres/backend.test.ts
+++ b/packages/openworkflow/postgres/backend.test.ts
@@ -1,6 +1,11 @@
 import { testBackend } from "../backend.testsuite.js";
 import { BackendPostgres } from "./backend.js";
-import { DEFAULT_POSTGRES_URL } from "./postgres.js";
+import {
+  DEFAULT_POSTGRES_URL,
+  Postgres,
+  dropSchema,
+  newPostgresMaxOne,
+} from "./postgres.js";
 import assert from "node:assert";
 import { randomUUID } from "node:crypto";
 import { describe, expect, test } from "vitest";
@@ -25,5 +30,59 @@ describe("BackendPostgres.connect errors", () => {
     await expect(BackendPostgres.connect("not-a-valid-url")).rejects.toThrow(
       /Postgres backend failed to connect.*postgresql:\/\/user:pass@host:port\/db.*:/,
     );
+  });
+
+  test("throws a clear error for invalid schema names", async () => {
+    await expect(
+      BackendPostgres.connect(DEFAULT_POSTGRES_URL, {
+        schema: "invalid-schema",
+      }),
+    ).rejects.toThrow(/Invalid schema name/);
+  });
+});
+
+describe("BackendPostgres schema option", () => {
+  test("stores workflow data in the configured schema", async () => {
+    const schema = `test_schema_${randomUUID().replaceAll("-", "_")}`;
+    const namespaceId = randomUUID();
+    const backend = await BackendPostgres.connect(DEFAULT_POSTGRES_URL, {
+      namespaceId,
+      schema,
+    });
+
+    try {
+      const workflowRun = await backend.createWorkflowRun({
+        workflowName: "schema-test",
+        version: null,
+        idempotencyKey: null,
+        input: null,
+        config: {},
+        context: null,
+        availableAt: null,
+        deadlineAt: null,
+      });
+
+      const internalBackend = backend as unknown as {
+        pg: Postgres;
+        schema: string;
+      };
+      const workflowRunsTable = internalBackend.pg`${internalBackend.pg(internalBackend.schema)}.${internalBackend.pg("workflow_runs")}`;
+
+      const [record] = await internalBackend.pg<{ id: string }[]>`
+        SELECT "id"
+        FROM ${workflowRunsTable}
+        WHERE "namespace_id" = ${namespaceId}
+          AND "id" = ${workflowRun.id}
+        LIMIT 1
+      `;
+
+      expect(record?.id).toBe(workflowRun.id);
+    } finally {
+      await backend.stop();
+
+      const pg = newPostgresMaxOne(DEFAULT_POSTGRES_URL);
+      await dropSchema(pg, schema);
+      await pg.end();
+    }
   });
 });

--- a/packages/openworkflow/postgres/backend.ts
+++ b/packages/openworkflow/postgres/backend.ts
@@ -29,6 +29,7 @@ import {
   Postgres,
   migrate,
   DEFAULT_SCHEMA,
+  assertValidSchemaName,
 } from "./postgres.js";
 
 const DEFAULT_PAGINATION_PAGE_SIZE = 100;
@@ -36,6 +37,7 @@ const DEFAULT_PAGINATION_PAGE_SIZE = 100;
 interface BackendPostgresOptions {
   namespaceId?: string;
   runMigrations?: boolean;
+  schema?: string;
 }
 
 /**
@@ -44,10 +46,12 @@ interface BackendPostgresOptions {
 export class BackendPostgres implements Backend {
   private pg: Postgres;
   private namespaceId: string;
+  private schema: string;
 
-  private constructor(pg: Postgres, namespaceId: string) {
+  private constructor(pg: Postgres, namespaceId: string, schema: string) {
     this.pg = pg;
     this.namespaceId = namespaceId;
+    this.schema = schema;
   }
 
   /**
@@ -63,21 +67,23 @@ export class BackendPostgres implements Backend {
     url: string,
     options?: BackendPostgresOptions,
   ): Promise<BackendPostgres> {
-    const { namespaceId, runMigrations } = {
+    const { namespaceId, runMigrations, schema } = {
       namespaceId: DEFAULT_NAMESPACE_ID,
       runMigrations: true,
+      schema: DEFAULT_SCHEMA,
       ...options,
     };
+    assertValidSchemaName(schema);
 
     try {
       if (runMigrations) {
         const pgForMigrate = newPostgresMaxOne(url);
-        await migrate(pgForMigrate, DEFAULT_SCHEMA);
+        await migrate(pgForMigrate, schema);
         await pgForMigrate.end();
       }
 
       const pg = newPostgres(url);
-      return new BackendPostgres(pg, namespaceId);
+      return new BackendPostgres(pg, namespaceId, schema);
     } catch (error) {
       throw wrapError(
         'Postgres backend failed to connect. Check the connection URL (e.g. "postgresql://user:pass@host:port/db").',
@@ -132,8 +138,10 @@ export class BackendPostgres implements Backend {
     pg: Postgres,
     params: CreateWorkflowRunParams,
   ): Promise<WorkflowRun> {
+    const workflowRunsTable = this.workflowRunsTable(pg);
+
     const [workflowRun] = await pg<WorkflowRun[]>`
-      INSERT INTO "openworkflow"."workflow_runs" (
+      INSERT INTO ${workflowRunsTable} (
         "namespace_id",
         "id",
         "workflow_name",
@@ -179,9 +187,11 @@ export class BackendPostgres implements Backend {
     idempotencyKey: string,
     createdAt: Date,
   ): Promise<WorkflowRun | null> {
+    const workflowRunsTable = this.workflowRunsTable(pg);
+
     const [workflowRun] = await pg<WorkflowRun[]>`
       SELECT *
-      FROM "openworkflow"."workflow_runs"
+      FROM ${workflowRunsTable}
       WHERE "namespace_id" = ${this.namespaceId}
         AND "workflow_name" = ${workflowName}
         AND "idempotency_key" = ${idempotencyKey}
@@ -196,9 +206,11 @@ export class BackendPostgres implements Backend {
   async getWorkflowRun(
     params: GetWorkflowRunParams,
   ): Promise<WorkflowRun | null> {
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [workflowRun] = await this.pg<WorkflowRun[]>`
       SELECT *
-      FROM "openworkflow"."workflow_runs"
+      FROM ${workflowRunsTable}
       WHERE "namespace_id" = ${this.namespaceId}
       AND "id" = ${params.workflowRunId}
       LIMIT 1
@@ -224,10 +236,11 @@ export class BackendPostgres implements Backend {
     const order = before
       ? this.pg`ORDER BY "created_at" ASC, "id" ASC`
       : this.pg`ORDER BY "created_at" DESC, "id" DESC`;
+    const workflowRunsTable = this.workflowRunsTable();
 
     const rows = await this.pg<WorkflowRun[]>`
       SELECT *
-      FROM "openworkflow"."workflow_runs"
+      FROM ${workflowRunsTable}
       WHERE ${whereClause}
       ${order}
       LIMIT ${limit + 1}
@@ -268,9 +281,11 @@ export class BackendPostgres implements Backend {
     // 1. mark any deadline-expired workflow runs as failed
     // 2. find an available workflow run to claim
     // 3. claim the workflow run
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [claimed] = await this.pg<WorkflowRun[]>`
       WITH expired AS (
-        UPDATE "openworkflow"."workflow_runs"
+        UPDATE ${workflowRunsTable}
         SET
           "status" = 'failed',
           "error" = ${this.pg.json({ message: "Workflow run deadline exceeded" })},
@@ -286,7 +301,7 @@ export class BackendPostgres implements Backend {
       ),
       candidate AS (
         SELECT "id"
-        FROM "openworkflow"."workflow_runs"
+        FROM ${workflowRunsTable}
         WHERE "namespace_id" = ${this.namespaceId}
           AND "status" IN ('pending', 'running', 'sleeping')
           AND "available_at" <= NOW()
@@ -298,7 +313,7 @@ export class BackendPostgres implements Backend {
         LIMIT 1
         FOR UPDATE SKIP LOCKED
       )
-      UPDATE "openworkflow"."workflow_runs" AS wr
+      UPDATE ${workflowRunsTable} AS wr
       SET
         "status" = 'running',
         "attempts" = "attempts" + 1,
@@ -318,8 +333,10 @@ export class BackendPostgres implements Backend {
   async extendWorkflowRunLease(
     params: ExtendWorkflowRunLeaseParams,
   ): Promise<WorkflowRun> {
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [updated] = await this.pg<WorkflowRun[]>`
-      UPDATE "openworkflow"."workflow_runs"
+      UPDATE ${workflowRunsTable}
       SET
         "available_at" = ${this.pg`NOW() + ${params.leaseDurationMs} * INTERVAL '1 millisecond'`},
         "updated_at" = NOW()
@@ -337,8 +354,10 @@ export class BackendPostgres implements Backend {
 
   async sleepWorkflowRun(params: SleepWorkflowRunParams): Promise<WorkflowRun> {
     // 'succeeded' status is deprecated
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [updated] = await this.pg<WorkflowRun[]>`
-      UPDATE "openworkflow"."workflow_runs"
+      UPDATE ${workflowRunsTable}
       SET
         "status" = 'sleeping',
         "available_at" = ${params.availableAt},
@@ -362,8 +381,10 @@ export class BackendPostgres implements Backend {
   async completeWorkflowRun(
     params: CompleteWorkflowRunParams,
   ): Promise<WorkflowRun> {
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [updated] = await this.pg<WorkflowRun[]>`
-      UPDATE "openworkflow"."workflow_runs"
+      UPDATE ${workflowRunsTable}
       SET
         "status" = 'completed',
         "output" = ${this.pg.json(params.output)},
@@ -399,8 +420,10 @@ export class BackendPostgres implements Backend {
       currentTime,
     );
 
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [updated] = await this.pg<WorkflowRun[]>`
-      UPDATE "openworkflow"."workflow_runs"
+      UPDATE ${workflowRunsTable}
       SET
         "status" = ${failureUpdate.status},
         "available_at" = ${failureUpdate.availableAt},
@@ -424,8 +447,10 @@ export class BackendPostgres implements Backend {
   async cancelWorkflowRun(
     params: CancelWorkflowRunParams,
   ): Promise<WorkflowRun> {
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [updated] = await this.pg<WorkflowRun[]>`
-      UPDATE "openworkflow"."workflow_runs"
+      UPDATE ${workflowRunsTable}
       SET
         "status" = 'canceled',
         "worker_id" = NULL,
@@ -469,8 +494,10 @@ export class BackendPostgres implements Backend {
   async createStepAttempt(
     params: CreateStepAttemptParams,
   ): Promise<StepAttempt> {
+    const stepAttemptsTable = this.stepAttemptsTable();
+
     const [stepAttempt] = await this.pg<StepAttempt[]>`
-      INSERT INTO "openworkflow"."step_attempts" (
+      INSERT INTO ${stepAttemptsTable} (
         "namespace_id",
         "id",
         "workflow_run_id",
@@ -507,9 +534,11 @@ export class BackendPostgres implements Backend {
   async getStepAttempt(
     params: GetStepAttemptParams,
   ): Promise<StepAttempt | null> {
+    const stepAttemptsTable = this.stepAttemptsTable();
+
     const [stepAttempt] = await this.pg<StepAttempt[]>`
       SELECT *
-      FROM "openworkflow"."step_attempts"
+      FROM ${stepAttemptsTable}
       WHERE "namespace_id" = ${this.namespaceId}
       AND "id" = ${params.stepAttemptId}
       LIMIT 1
@@ -534,10 +563,11 @@ export class BackendPostgres implements Backend {
     const order = before
       ? this.pg`ORDER BY "created_at" DESC, "id" DESC`
       : this.pg`ORDER BY "created_at" ASC, "id" ASC`;
+    const stepAttemptsTable = this.stepAttemptsTable();
 
     const rows = await this.pg<StepAttempt[]>`
       SELECT *
-      FROM "openworkflow"."step_attempts"
+      FROM ${stepAttemptsTable}
       WHERE ${whereClause}
       ${order}
       LIMIT ${limit + 1}
@@ -619,15 +649,18 @@ export class BackendPostgres implements Backend {
   async completeStepAttempt(
     params: CompleteStepAttemptParams,
   ): Promise<StepAttempt> {
+    const stepAttemptsTable = this.stepAttemptsTable();
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [updated] = await this.pg<StepAttempt[]>`
-      UPDATE "openworkflow"."step_attempts" sa
+      UPDATE ${stepAttemptsTable} sa
       SET
         "status" = 'completed',
         "output" = ${this.pg.json(params.output)},
         "error" = NULL,
         "finished_at" = NOW(),
         "updated_at" = NOW()
-      FROM "openworkflow"."workflow_runs" wr
+      FROM ${workflowRunsTable} wr
       WHERE sa."namespace_id" = ${this.namespaceId}
       AND sa."workflow_run_id" = ${params.workflowRunId}
       AND sa."id" = ${params.stepAttemptId}
@@ -645,15 +678,18 @@ export class BackendPostgres implements Backend {
   }
 
   async failStepAttempt(params: FailStepAttemptParams): Promise<StepAttempt> {
+    const stepAttemptsTable = this.stepAttemptsTable();
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [updated] = await this.pg<StepAttempt[]>`
-      UPDATE "openworkflow"."step_attempts" sa
+      UPDATE ${stepAttemptsTable} sa
       SET
         "status" = 'failed',
         "output" = NULL,
         "error" = ${this.pg.json(params.error)},
         "finished_at" = NOW(),
         "updated_at" = NOW()
-      FROM "openworkflow"."workflow_runs" wr
+      FROM ${workflowRunsTable} wr
       WHERE sa."namespace_id" = ${this.namespaceId}
       AND sa."workflow_run_id" = ${params.workflowRunId}
       AND sa."id" = ${params.stepAttemptId}
@@ -668,6 +704,14 @@ export class BackendPostgres implements Backend {
     if (!updated) throw new Error("Failed to mark step attempt failed");
 
     return updated;
+  }
+
+  private workflowRunsTable(pg: Postgres = this.pg) {
+    return pg`${pg(this.schema)}.${pg("workflow_runs")}`;
+  }
+
+  private stepAttemptsTable(pg: Postgres = this.pg) {
+    return pg`${pg(this.schema)}.${pg("step_attempts")}`;
   }
 }
 

--- a/packages/openworkflow/postgres/postgres.test.ts
+++ b/packages/openworkflow/postgres/postgres.test.ts
@@ -38,6 +38,10 @@ describe("postgres", () => {
         expect(mig).not.toContain(`"openworkflow"`);
       }
     });
+
+    test("throws for invalid schema names", () => {
+      expect(() => migrations("invalid-schema")).toThrow(/Invalid schema name/);
+    });
   });
 
   describe("migrate()", () => {

--- a/packages/openworkflow/postgres/postgres.ts
+++ b/packages/openworkflow/postgres/postgres.ts
@@ -3,15 +3,13 @@ import postgres from "postgres";
 export const DEFAULT_POSTGRES_URL =
   "postgresql://postgres:postgres@localhost:5432/postgres";
 
-// The default schema to use for OpenWorkflow data. This type is more for
-// documentation than for practical use. The only time we allow schema
-// customization is during testing, specifically for testing migrations.
-// Everywhere else uses the "openworkflow" schema directly for prepared
-// statements.
+// The default schema to use for OpenWorkflow data.
 export const DEFAULT_SCHEMA = "openworkflow";
 
 export type Postgres = ReturnType<typeof postgres>;
 export type PostgresOptions = Parameters<typeof postgres>[1];
+
+const SCHEMA_NAME_PATTERN = /^[a-zA-Z_]\w*$/;
 
 /**
  * newPostgres creates a new Postgres client.
@@ -40,17 +38,20 @@ export function newPostgresMaxOne(url: string, options?: PostgresOptions) {
  * @returns Migration SQL statements
  */
 export function migrations(schema: string): string[] {
+  assertValidSchemaName(schema);
+  const quotedSchema = quoteIdentifier(schema);
+
   return [
     // 0 - init
     `BEGIN;
 
-    CREATE SCHEMA IF NOT EXISTS ${schema};
+    CREATE SCHEMA IF NOT EXISTS ${quotedSchema};
 
-    CREATE TABLE IF NOT EXISTS "${schema}"."openworkflow_migrations" (
+    CREATE TABLE IF NOT EXISTS ${quotedSchema}."openworkflow_migrations" (
       "version" BIGINT NOT NULL PRIMARY KEY
     );
 
-    INSERT INTO "${schema}"."openworkflow_migrations" ("version")
+    INSERT INTO ${quotedSchema}."openworkflow_migrations" ("version")
     VALUES (0)
     ON CONFLICT DO NOTHING;
 
@@ -59,7 +60,7 @@ export function migrations(schema: string): string[] {
     // 1 - add workflow_runs and step_attempts tables
     `BEGIN;
 
-    CREATE TABLE IF NOT EXISTS "${schema}"."workflow_runs" (
+    CREATE TABLE IF NOT EXISTS ${quotedSchema}."workflow_runs" (
       "namespace_id" TEXT NOT NULL,
       "id" TEXT NOT NULL,
       --
@@ -85,7 +86,7 @@ export function migrations(schema: string): string[] {
       PRIMARY KEY ("namespace_id", "id")
     );
 
-    CREATE TABLE IF NOT EXISTS "${schema}"."step_attempts" (
+    CREATE TABLE IF NOT EXISTS ${quotedSchema}."step_attempts" (
       "namespace_id" TEXT NOT NULL,
       "id" TEXT NOT NULL,
       --
@@ -106,7 +107,7 @@ export function migrations(schema: string): string[] {
       PRIMARY KEY ("namespace_id", "id")
     );
 
-    INSERT INTO "${schema}"."openworkflow_migrations" ("version")
+    INSERT INTO ${quotedSchema}."openworkflow_migrations" ("version")
     VALUES (1)
     ON CONFLICT DO NOTHING;
     
@@ -115,28 +116,28 @@ export function migrations(schema: string): string[] {
     // 2 - foreign keys
     `BEGIN;
 
-    ALTER TABLE "${schema}"."step_attempts"
+    ALTER TABLE ${quotedSchema}."step_attempts"
     ADD CONSTRAINT "step_attempts_workflow_run_fk"
     FOREIGN KEY ("namespace_id", "workflow_run_id")
-    REFERENCES "${schema}"."workflow_runs" ("namespace_id", "id")
+    REFERENCES ${quotedSchema}."workflow_runs" ("namespace_id", "id")
     ON DELETE CASCADE
     NOT VALID;
 
-    ALTER TABLE "${schema}"."workflow_runs"
+    ALTER TABLE ${quotedSchema}."workflow_runs"
     ADD CONSTRAINT "workflow_runs_parent_step_attempt_fk"
     FOREIGN KEY ("parent_step_attempt_namespace_id", "parent_step_attempt_id")
-    REFERENCES "${schema}"."step_attempts" ("namespace_id", "id")
+    REFERENCES ${quotedSchema}."step_attempts" ("namespace_id", "id")
     ON DELETE SET NULL
     NOT VALID;
 
-    ALTER TABLE "${schema}"."step_attempts"
+    ALTER TABLE ${quotedSchema}."step_attempts"
     ADD CONSTRAINT "step_attempts_child_workflow_run_fk"
     FOREIGN KEY ("child_workflow_run_namespace_id", "child_workflow_run_id")
-    REFERENCES "${schema}"."workflow_runs" ("namespace_id", "id")
+    REFERENCES ${quotedSchema}."workflow_runs" ("namespace_id", "id")
     ON DELETE SET NULL
     NOT VALID;
 
-    INSERT INTO "${schema}"."openworkflow_migrations" ("version")
+    INSERT INTO ${quotedSchema}."openworkflow_migrations" ("version")
     VALUES (2)
     ON CONFLICT DO NOTHING;
 
@@ -145,16 +146,16 @@ export function migrations(schema: string): string[] {
     // 3 - validate foreign keys
     `BEGIN;
 
-    ALTER TABLE "${schema}"."step_attempts"
+    ALTER TABLE ${quotedSchema}."step_attempts"
     VALIDATE CONSTRAINT "step_attempts_workflow_run_fk";
     
-    ALTER TABLE "${schema}"."workflow_runs" VALIDATE CONSTRAINT
+    ALTER TABLE ${quotedSchema}."workflow_runs" VALIDATE CONSTRAINT
     "workflow_runs_parent_step_attempt_fk";
 
-    ALTER TABLE "${schema}"."step_attempts"
+    ALTER TABLE ${quotedSchema}."step_attempts"
     VALIDATE CONSTRAINT "step_attempts_child_workflow_run_fk";
 
-    INSERT INTO "${schema}"."openworkflow_migrations" ("version")
+    INSERT INTO ${quotedSchema}."openworkflow_migrations" ("version")
     VALUES (3)
     ON CONFLICT DO NOTHING;
 
@@ -164,35 +165,35 @@ export function migrations(schema: string): string[] {
     `BEGIN;
 
     CREATE INDEX IF NOT EXISTS "workflow_runs_status_available_at_created_at_idx"
-    ON "${schema}"."workflow_runs" ("namespace_id", "status", "available_at", "created_at");
+    ON ${quotedSchema}."workflow_runs" ("namespace_id", "status", "available_at", "created_at");
 
     CREATE INDEX IF NOT EXISTS "workflow_runs_workflow_name_idempotency_key_created_at_idx"
-    ON "${schema}"."workflow_runs" ("namespace_id", "workflow_name", "idempotency_key", "created_at");
+    ON ${quotedSchema}."workflow_runs" ("namespace_id", "workflow_name", "idempotency_key", "created_at");
 
     CREATE INDEX IF NOT EXISTS "workflow_runs_parent_step_idx"
-    ON "${schema}"."workflow_runs" ("parent_step_attempt_namespace_id", "parent_step_attempt_id")
+    ON ${quotedSchema}."workflow_runs" ("parent_step_attempt_namespace_id", "parent_step_attempt_id")
     WHERE parent_step_attempt_namespace_id IS NOT NULL AND parent_step_attempt_id IS NOT NULL;
 
     CREATE INDEX IF NOT EXISTS "workflow_runs_created_at_desc_idx"
-    ON "${schema}"."workflow_runs" ("namespace_id", "created_at" DESC);
+    ON ${quotedSchema}."workflow_runs" ("namespace_id", "created_at" DESC);
 
     CREATE INDEX IF NOT EXISTS "workflow_runs_status_created_at_desc_idx"
-    ON "${schema}"."workflow_runs" ("namespace_id", "status", "created_at" DESC);
+    ON ${quotedSchema}."workflow_runs" ("namespace_id", "status", "created_at" DESC);
 
     CREATE INDEX IF NOT EXISTS "workflow_runs_workflow_name_status_created_at_desc_idx"
-    ON "${schema}"."workflow_runs" ("namespace_id", "workflow_name", "status", "created_at" DESC);
+    ON ${quotedSchema}."workflow_runs" ("namespace_id", "workflow_name", "status", "created_at" DESC);
 
     CREATE INDEX IF NOT EXISTS "step_attempts_workflow_run_created_at_idx"
-    ON "${schema}"."step_attempts" ("namespace_id", "workflow_run_id", "created_at");
+    ON ${quotedSchema}."step_attempts" ("namespace_id", "workflow_run_id", "created_at");
 
     CREATE INDEX IF NOT EXISTS "step_attempts_workflow_run_step_name_created_at_idx"
-    ON "${schema}"."step_attempts" ("namespace_id", "workflow_run_id", "step_name", "created_at");
+    ON ${quotedSchema}."step_attempts" ("namespace_id", "workflow_run_id", "step_name", "created_at");
 
     CREATE INDEX IF NOT EXISTS "step_attempts_child_workflow_run_idx"
-    ON "${schema}"."step_attempts" ("child_workflow_run_namespace_id", "child_workflow_run_id")
+    ON ${quotedSchema}."step_attempts" ("child_workflow_run_namespace_id", "child_workflow_run_id")
     WHERE child_workflow_run_namespace_id IS NOT NULL AND child_workflow_run_id IS NOT NULL;
 
-    INSERT INTO "${schema}"."openworkflow_migrations"("version")
+    INSERT INTO ${quotedSchema}."openworkflow_migrations"("version")
     VALUES (4)
     ON CONFLICT DO NOTHING;
 
@@ -224,7 +225,8 @@ export async function migrate(pg: Postgres, schema: string) {
  * @returns Promise resolved when the schema is dropped
  */
 export async function dropSchema(pg: Postgres, schema: string) {
-  await pg.unsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE;`);
+  assertValidSchemaName(schema);
+  await pg.unsafe(`DROP SCHEMA IF EXISTS ${quoteIdentifier(schema)} CASCADE;`);
 }
 
 /**
@@ -237,19 +239,47 @@ async function getCurrentMigrationVersion(
   pg: Postgres,
   schema: string,
 ): Promise<number> {
+  assertValidSchemaName(schema);
+
   // check if migrations table exists
-  const existsRes = await pg.unsafe<{ exists: boolean }[]>(`
+  const existsRes = await pg.unsafe<{ exists: boolean }[]>(
+    `
     SELECT EXISTS (
       SELECT 1
       FROM information_schema.tables
-      WHERE table_schema = '${schema}'
+      WHERE table_schema = $1
       AND table_name = 'openworkflow_migrations'
-    )`);
+    )`,
+    [schema],
+  );
   if (!existsRes[0]?.exists) return -1;
 
   // get current version
+  const quotedSchema = quoteIdentifier(schema);
   const currentVersionRes = await pg.unsafe<{ version: number }[]>(
-    `SELECT MAX("version") AS "version" FROM "${schema}"."openworkflow_migrations";`,
+    `SELECT MAX("version") AS "version" FROM ${quotedSchema}."openworkflow_migrations";`,
   );
   return currentVersionRes[0]?.version ?? -1;
+}
+
+/**
+ * assertValidSchemaName validates Postgres schema names used by OpenWorkflow.
+ * @param schema - Schema name to validate
+ * @throws {Error} If the schema name is not a valid Postgres identifier
+ */
+export function assertValidSchemaName(schema: string): void {
+  if (!SCHEMA_NAME_PATTERN.test(schema)) {
+    throw new Error(
+      `Invalid schema name "${schema}". Use a Postgres identifier (letters, numbers, underscores; cannot start with a number).`,
+    );
+  }
+}
+
+/**
+ * quoteIdentifier returns a SQL-quoted identifier.
+ * @param identifier - Identifier that has already been validated
+ * @returns Quoted identifier
+ */
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier}"`;
 }


### PR DESCRIPTION
## Summary
- add optional  to  options (default )
- route Postgres runtime queries through schema-aware identifiers instead of hardcoded 
- validate schema names before running migrations/queries and harden migration SQL interpolation
- update docs for Postgres/production to describe configurable schema usage
- add tests for custom schema behavior and invalid schema names

## Notes
- this keeps existing behavior unchanged when  is omitted
- motivated by #291

Closes #291