### PR TITLE
Add step-level retry policies

### DIFF
--- a/packages/docs/docs/advanced-patterns.mdx
+++ b/packages/docs/docs/advanced-patterns.mdx
@@ -39,7 +39,7 @@ const data = await step.run({ name: "fetch-external-api" }, async () => {
 ```
 
 The default retry behavior works well for most cases. Configure retry behavior
-at the workflow level with `retryPolicy`, or handle errors explicitly in your
+per step with `step.run({ retryPolicy })`, or handle errors explicitly in your
 step functions for custom logic. See [Retries](/docs/retries) for details.
 
 ## Sleeping (Pausing) Workflows

--- a/packages/docs/docs/retries.mdx
+++ b/packages/docs/docs/retries.mdx
@@ -45,9 +45,13 @@ Each retry:
 - Returns cached results for completed steps
 - Re-executes the failed step
 
-## Exponential Backoff
+## Retry Policy
 
-Failed workflows are rescheduled with increasing delays:
+Both steps and workflows use the same retry policy shape. A retry policy
+controls exponential backoff — how long to wait between retries, how fast delays
+grow, and when to stop retrying.
+
+With the defaults, retry delays look like this:
 
 | Attempt | Delay     |
 | ------- | --------- |
@@ -58,28 +62,58 @@ Failed workflows are rescheduled with increasing delays:
 | 5       | ~8s       |
 | ...     | ...       |
 
-This prevents overwhelming external services during outages.
+This prevents overwhelming external services during outages. Retries continue
+until canceled, until `deadlineAt` is reached (or the next retry would pass it),
+or until `maximumAttempts` is exhausted.
 
-By default, retries continue until canceled or until `deadlineAt` is reached (or
-the next retry would pass it). If `maximumAttempts` is configured, the workflow
-is also marked `failed` once that limit is reached.
+Retry policies have the following fields:
 
-## Retry Policy
+| Field                | Default    | Description                                         |
+| -------------------- | ---------- | --------------------------------------------------- |
+| `initialInterval`    | `"1s"`     | Delay before the first retry after a failed attempt |
+| `backoffCoefficient` | `2`        | Multiplier applied to each subsequent retry delay   |
+| `maximumInterval`    | `"100s"`   | Upper bound for retry delay                         |
+| `maximumAttempts`    | `Infinity` | Maximum attempts, including the initial one         |
 
-Retry behavior is configured per workflow using `retryPolicy` in the workflow
-spec:
+### Step Retry Policy
+
+Each `step.run(...)` can define its own retry policy. If you omit `retryPolicy`,
+OpenWorkflow uses the defaults shown above.
+
+```ts
+await step.run(
+  {
+    name: "call-api",
+    retryPolicy: {
+      initialInterval: "500ms",
+      backoffCoefficient: 2,
+      maximumInterval: "30s",
+      maximumAttempts: 5,
+    },
+  },
+  async () => {
+    // step logic
+  },
+);
+```
+
+### Workflow Retry Policy
+
+Workflow-level `retryPolicy` applies to non-step failures — for example, missing
+workflow definitions or errors thrown outside `step.run`. If you omit
+`retryPolicy` (or individual fields), OpenWorkflow uses the same defaults.
 
 ```ts
 import { defineWorkflow } from "openworkflow";
 
-export const chargeCustomer = defineWorkflow(
+defineWorkflow(
   {
     name: "charge-customer",
     retryPolicy: {
-      initialInterval: "1s",
+      initialInterval: "500ms",
       backoffCoefficient: 2,
-      maximumInterval: "100s",
-      maximumAttempts: Infinity,
+      maximumInterval: "30s",
+      maximumAttempts: 5,
     },
   },
   async ({ step }) => {
@@ -87,15 +121,6 @@ export const chargeCustomer = defineWorkflow(
   },
 );
 ```
-
-`retryPolicy` is optional. Any omitted fields use defaults.
-
-| Field                | Description                                           |
-| -------------------- | ----------------------------------------------------- |
-| `initialInterval`    | Delay before the first retry after a failed attempt   |
-| `backoffCoefficient` | Multiplier applied to each subsequent retry delay     |
-| `maximumInterval`    | Upper bound for retry delay                           |
-| `maximumAttempts`    | Maximum total attempts, including the initial attempt |
 
 ## What Triggers a Retry
 

--- a/packages/docs/docs/steps.mdx
+++ b/packages/docs/docs/steps.mdx
@@ -22,9 +22,9 @@ const result = await step.run({ name: "fetch-user" }, async () => {
 });
 ```
 
-The first argument is a config object with the step name. The second argument is
-the async function to execute. The function's return value is stored and
-returned on subsequent replays.
+The first argument is a config object with the step name (and optional
+`retryPolicy`). The second argument is the async function to execute. The
+function's return value is stored and returned on subsequent replays.
 
 ## Why Steps Matter
 
@@ -137,6 +137,31 @@ Pauses the workflow until a specified duration has elapsed. See
 ```ts
 await step.sleep("wait-one-hour", "1h");
 ```
+
+## Retry Policy (Optional)
+
+Control backoff and retry limits for an individual step:
+
+```ts
+await step.run(
+  {
+    name: "charge-card",
+    retryPolicy: {
+      initialInterval: "1s",
+      backoffCoefficient: 2,
+      maximumInterval: "30s",
+      maximumAttempts: 5,
+    },
+  },
+  async () => {
+    await payments.charge();
+  },
+);
+```
+
+Any `retryPolicy` fields you omit fall back to defaults. Step retry policies
+are independent from the workflow-level retry policy. See
+[Retries](/docs/retries) for the full behavior and defaults.
 
 ## Error Handling
 

--- a/packages/openworkflow/backend.testsuite.ts
+++ b/packages/openworkflow/backend.testsuite.ts
@@ -919,7 +919,7 @@ export function testBackend(options: TestBackendOptions): void {
         const updated =
           await backend.rescheduleWorkflowRunAfterFailedStepAttempt({
             workflowRunId: claimed.id,
-            workerId: claimed.workerId ?? "",
+            workerId: claimed.workerId!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
             error,
             availableAt,
           });

--- a/packages/openworkflow/backend.ts
+++ b/packages/openworkflow/backend.ts
@@ -36,6 +36,9 @@ export interface Backend {
   failWorkflowRun(
     params: Readonly<FailWorkflowRunParams>,
   ): Promise<WorkflowRun>;
+  rescheduleWorkflowRunAfterFailedStepAttempt(
+    params: Readonly<RescheduleWorkflowRunAfterFailedStepAttemptParams>,
+  ): Promise<WorkflowRun>;
   cancelWorkflowRun(
     params: Readonly<CancelWorkflowRunParams>,
   ): Promise<WorkflowRun>;
@@ -106,6 +109,13 @@ export interface FailWorkflowRunParams {
   workerId: string;
   error: SerializedError;
   retryPolicy: RetryPolicy;
+}
+
+export interface RescheduleWorkflowRunAfterFailedStepAttemptParams {
+  workflowRunId: string;
+  workerId: string;
+  error: SerializedError;
+  availableAt: Date;
 }
 
 export interface CancelWorkflowRunParams {

--- a/packages/openworkflow/execution.test.ts
+++ b/packages/openworkflow/execution.test.ts
@@ -610,13 +610,15 @@ function sleep(ms: number): Promise<void> {
 function createMockStepAttempt(
   overrides: Partial<StepAttempt> = {},
 ): StepAttempt {
+  const status = overrides.status ?? "completed";
+
   return {
     namespaceId: "default",
     id: "step-attempt-id",
     workflowRunId: "workflow-run-id",
     stepName: "step",
     kind: "function",
-    status: "completed",
+    status,
     config: {},
     context: null,
     output: null,
@@ -624,7 +626,8 @@ function createMockStepAttempt(
     childWorkflowRunNamespaceId: null,
     childWorkflowRunId: null,
     startedAt: new Date("2026-01-01T00:00:00.000Z"),
-    finishedAt: new Date("2026-01-01T00:00:01.000Z"),
+    finishedAt:
+      status === "running" ? null : new Date("2026-01-01T00:00:01.000Z"),
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
     updatedAt: new Date("2026-01-01T00:00:01.000Z"),
     ...overrides,

--- a/packages/openworkflow/execution.test.ts
+++ b/packages/openworkflow/execution.test.ts
@@ -1,4 +1,6 @@
 import { OpenWorkflow } from "./client.js";
+import type { StepAttempt } from "./core/step.js";
+import { createStepExecutionStateFromAttempts } from "./execution.js";
 import { BackendPostgres } from "./postgres.js";
 import { DEFAULT_POSTGRES_URL } from "./postgres/postgres.js";
 import { randomUUID } from "node:crypto";
@@ -540,6 +542,61 @@ describe("executeWorkflow", () => {
   });
 });
 
+describe("createStepExecutionStateFromAttempts", () => {
+  test("builds successful cache and failed-count map from mixed history", () => {
+    const completed = createMockStepAttempt({
+      id: "completed-a",
+      stepName: "step-a",
+      status: "completed",
+      output: "a",
+    });
+    const failedA1 = createMockStepAttempt({
+      id: "failed-a-1",
+      stepName: "step-a",
+      status: "failed",
+    });
+    const failedA2 = createMockStepAttempt({
+      id: "failed-a-2",
+      stepName: "step-a",
+      status: "failed",
+    });
+    const failedB = createMockStepAttempt({
+      id: "failed-b",
+      stepName: "step-b",
+      status: "failed",
+    });
+    const running = createMockStepAttempt({
+      id: "running-c",
+      stepName: "step-c",
+      status: "running",
+    });
+
+    const state = createStepExecutionStateFromAttempts([
+      completed,
+      failedA1,
+      failedA2,
+      failedB,
+      running,
+    ]);
+
+    expect(state.cache.size).toBe(1);
+    expect(state.cache.get("step-a")).toBe(completed);
+    expect(state.cache.has("step-b")).toBe(false);
+    expect(state.cache.has("step-c")).toBe(false);
+
+    expect(state.failedCountsByStepName.get("step-a")).toBe(2);
+    expect(state.failedCountsByStepName.get("step-b")).toBe(1);
+    expect(state.failedCountsByStepName.has("step-c")).toBe(false);
+  });
+
+  test("returns empty cache and counts for empty history", () => {
+    const state = createStepExecutionStateFromAttempts([]);
+
+    expect(state.cache.size).toBe(0);
+    expect(state.failedCountsByStepName.size).toBe(0);
+  });
+});
+
 async function createBackend(): Promise<BackendPostgres> {
   return await BackendPostgres.connect(DEFAULT_POSTGRES_URL, {
     namespaceId: randomUUID(),
@@ -548,4 +605,28 @@ async function createBackend(): Promise<BackendPostgres> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createMockStepAttempt(
+  overrides: Partial<StepAttempt> = {},
+): StepAttempt {
+  return {
+    namespaceId: "default",
+    id: "step-attempt-id",
+    workflowRunId: "workflow-run-id",
+    stepName: "step",
+    kind: "function",
+    status: "completed",
+    config: {},
+    context: null,
+    output: null,
+    error: null,
+    childWorkflowRunNamespaceId: null,
+    childWorkflowRunId: null,
+    startedAt: new Date("2026-01-01T00:00:00.000Z"),
+    finishedAt: new Date("2026-01-01T00:00:01.000Z"),
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:01.000Z"),
+    ...overrides,
+  };
 }

--- a/packages/openworkflow/execution.ts
+++ b/packages/openworkflow/execution.ts
@@ -422,10 +422,6 @@ export async function executeWorkflow(
         return;
       }
 
-      if (!retryDecision.availableAt) {
-        throw new Error("Step retry decision missing availableAt");
-      }
-
       await backend.rescheduleWorkflowRunAfterFailedStepAttempt({
         workflowRunId: workflowRun.id,
         workerId,

--- a/packages/openworkflow/execution.ts
+++ b/packages/openworkflow/execution.ts
@@ -422,6 +422,13 @@ export async function executeWorkflow(
         return;
       }
 
+      if (!retryDecision.availableAt) {
+        // this should not happen when retry decision isn't failed
+        // throw error to avoid silently swallowing retries, which we should
+        // catch in tests if anything goes wrong
+        throw new Error("Step retry decision missing availableAt");
+      }
+
       await backend.rescheduleWorkflowRunAfterFailedStepAttempt({
         workflowRunId: workflowRun.id,
         workerId,

--- a/packages/openworkflow/execution.ts
+++ b/packages/openworkflow/execution.ts
@@ -422,12 +422,14 @@ export async function executeWorkflow(
         return;
       }
 
+      /* v8 ignore start -- defensive invariant */
       if (!retryDecision.availableAt) {
         // this should not happen when retry decision isn't failed
         // throw error to avoid silently swallowing retries, which we should
         // catch in tests if anything goes wrong
         throw new Error("Step retry decision missing availableAt");
       }
+      /* v8 ignore stop */
 
       await backend.rescheduleWorkflowRunAfterFailedStepAttempt({
         workflowRunId: workflowRun.id,


### PR DESCRIPTION
Adds per-step retry policies. Step failure backoff/budget decisions now use the step's own retry policy rather than the workflow's.

Example code:
```ts
await step.run(
  {
    name: "charge-card",
    retryPolicy: {
      initialInterval: "1s",
      backoffCoefficient: 2,
      maximumInterval: "30s",
      maximumAttempts: 5,
    },
  },
  async () => {
    await payments.charge();
  },
);
```