### PR TITLE
Add flag to CLI to specify config file

### DIFF
--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -15,18 +15,21 @@ const program = new Command();
 program
   .name("openworkflow")
   .description("OpenWorkflow CLI - learn more at https://openworkflow.dev")
+  .usage("<command> [options]")
   .version(getVersion());
 
 // init
 program
   .command("init")
   .description("initialize OpenWorkflow")
+  .option("--config <path>", "path to OpenWorkflow config file")
   .action(withErrorHandling(init));
 
 // doctor
 program
   .command("doctor")
   .description("check configuration and list available workflows")
+  .option("--config <path>", "path to OpenWorkflow config file")
   .action(withErrorHandling(doctor));
 
 // worker
@@ -41,12 +44,14 @@ workerCmd
     "number of concurrent workflows to process",
     Number.parseInt,
   )
+  .option("--config <path>", "path to OpenWorkflow config file")
   .action(withErrorHandling(workerStart));
 
 // dashboard
 program
   .command("dashboard")
   .description("start the dashboard to view workflow runs")
+  .option("--config <path>", "path to OpenWorkflow config file")
   .action(withErrorHandling(dashboard));
 
 await program.parseAsync(process.argv);

--- a/packages/docs/docs/cli.mdx
+++ b/packages/docs/docs/cli.mdx
@@ -5,7 +5,7 @@ description: Command-line interface for OpenWorkflow
 
 The OpenWorkflow CLI is the primary way to set up your project, run workers, and
 launch the dashboard. CLI commands read your `openworkflow.config.ts`
-automatically.
+automatically, or you can override the path with `--config`.
 
 ## Installation
 

--- a/packages/docs/docs/configuration.mdx
+++ b/packages/docs/docs/configuration.mdx
@@ -44,7 +44,11 @@ export default defineConfig({
 ```
 
 The CLI automatically finds this file by searching up from the current
-directory.
+directory. If your config lives somewhere else, pass an explicit path:
+
+```bash
+npx @openworkflow/cli worker start --config src/openworkflow.config.ts
+```
 
 ## Verify Configuration
 


### PR DESCRIPTION
Closes #284

Implements a git options style config flag:

```
openworkflow worker start --config src/openworkflow.config.ts
```