### PR TITLE
Fix hardcoded schema in Postgres reschedule query

### DIFF
--- a/packages/openworkflow/postgres/backend.ts
+++ b/packages/openworkflow/postgres/backend.ts
@@ -448,8 +448,10 @@ export class BackendPostgres implements Backend {
   async rescheduleWorkflowRunAfterFailedStepAttempt(
     params: RescheduleWorkflowRunAfterFailedStepAttemptParams,
   ): Promise<WorkflowRun> {
+    const workflowRunsTable = this.workflowRunsTable();
+
     const [updated] = await this.pg<WorkflowRun[]>`
-      UPDATE "openworkflow"."workflow_runs"
+      UPDATE ${workflowRunsTable}
       SET
         "status" = 'pending',
         "available_at" = ${params.availableAt},


### PR DESCRIPTION
## Summary
- replace the remaining hardcoded `"openworkflow"."workflow_runs"` update target in `BackendPostgres.rescheduleWorkflowRunAfterFailedStepAttempt` with the configured schema table helper
- add a regression test that exercises `rescheduleWorkflowRunAfterFailedStepAttempt` with a custom schema to prevent regressions

## Testing
- npm run ci
